### PR TITLE
improvement: PreferenceKeys holds now an Integer pointing to a string resource

### DIFF
--- a/app/src/main/java/com/edt/ut3/backend/preferences/PreferencesManager.kt
+++ b/app/src/main/java/com/edt/ut3/backend/preferences/PreferencesManager.kt
@@ -5,6 +5,7 @@ import android.content.SharedPreferences
 import android.content.res.Configuration
 import androidx.appcompat.app.AppCompatDelegate.*
 import androidx.preference.PreferenceManager
+import com.edt.ut3.R
 import com.edt.ut3.backend.calendar.CalendarMode
 import com.edt.ut3.backend.formation_choice.School
 import com.edt.ut3.backend.preferences.simple_preference.SimplePreference
@@ -43,89 +44,95 @@ class PreferencesManager private constructor(
     /**
      * Describes the different preferences keys.
      *
-     * @property key The key that is used to store
-     * the preference.
+     * @property _key The key that is used to store
+     * the preference. It must be a StringResource.
      */
-    sealed class PreferenceKeys<T>(val key: String, val defValue: T) {
-        object THEME: PreferenceKeys<ThemePreference>("theme", ThemePreference.SMARTPHONE)
-        object LINK: PreferenceKeys<String?>("link", null)
-        object GROUPS: PreferenceKeys<List<String>?>("groups", null)
-        object OLD_GROUPS: PreferenceKeys<List<String>?>("old_groups", null)
-        object CALENDAR_MODE: PreferenceKeys<CalendarMode>("calendar_mode", CalendarMode.default())
-        object NOTIFICATION: PreferenceKeys<Boolean>("actual_notification", true)
-        object FIRST_LAUNCH: PreferenceKeys<Boolean>("actual_first_launch", true)
-        object CODE_VERSION: PreferenceKeys<Int>("actual_code_version", 0)
+    sealed class PreferenceKeys<T>(private val _key: Int, val defValue: T) {
+        fun getKey(context: Context): String = context.getString(_key)
 
-        object DEPRECATED_FIRST_LAUNCH: PreferenceKeys<Boolean>("first_launch", true)
-        object DEPRECATED_NOTIFICATION: PreferenceKeys<Boolean>("notification", true)
+        object THEME: PreferenceKeys<ThemePreference>(R.string.key_theme, ThemePreference.SMARTPHONE)
+        object LINK: PreferenceKeys<String?>(R.string.key_link, null)
+        object GROUPS: PreferenceKeys<List<String>?>(R.string.key_group, null)
+        object OLD_GROUPS: PreferenceKeys<List<String>?>(R.string.old_key_group, null)
+        object CALENDAR_MODE: PreferenceKeys<CalendarMode>(R.string.key_calendar_mode, CalendarMode.default())
+        object NOTIFICATION: PreferenceKeys<Boolean>(R.string.key_notification, true)
+        object FIRST_LAUNCH: PreferenceKeys<Boolean>(R.string.key_first_launch, true)
+        object CODE_VERSION: PreferenceKeys<Int>(R.string.key_code_version, 0)
+
+        /**
+         * All of the following objects are deprecated and should not be used.
+         * They are kept here to ensure compatibility via the [CompatibilityManager][com.edt.ut3.compatibility.CompatibilityManager].
+         */
+        object DEPRECATED_FIRST_LAUNCH: PreferenceKeys<Boolean>(R.string.old_key_first_launch, true)
+        object DEPRECATED_NOTIFICATION: PreferenceKeys<Boolean>(R.string.old_key_notification, true)
     }
 
 
     var theme : ThemePreference by simplePreference.Delegate(
-        key = PreferenceKeys.THEME.key,
+        key = PreferenceKeys.THEME.getKey(context),
         defValue = PreferenceKeys.THEME.defValue.toString(),
         converter = ThemePreferenceConverter,
         manager = ThemePreferenceManager
     )
 
     var link : School.Info? by simplePreference.Delegate(
-        key = PreferenceKeys.LINK.key,
+        key = PreferenceKeys.LINK.getKey(context),
         defValue = PreferenceKeys.LINK.defValue,
         converter = InfoConverter,
         manager = InfoManager
     )
 
     var groups : List<String>? by simplePreference.Delegate <List<String>?, String>(
-        key = PreferenceKeys.GROUPS.key,
+        key = PreferenceKeys.GROUPS.getKey(context),
         defValue = PreferenceKeys.GROUPS.defValue.toString(),
         converter = StringListConverter,
         manager = NullableStringListManager
     )
 
     var oldGroups : List<String>? by simplePreference.Delegate(
-        key = PreferenceKeys.OLD_GROUPS.key,
+        key = PreferenceKeys.OLD_GROUPS.getKey(context),
         defValue = PreferenceKeys.OLD_GROUPS.defValue.toString(),
         converter = StringListConverter,
         manager = NullableStringListManager
     )
 
     var calendarMode : CalendarMode by simplePreference.Delegate(
-        key = PreferenceKeys.CALENDAR_MODE.key,
+        key = PreferenceKeys.CALENDAR_MODE.getKey(context),
         defValue = Json.encodeToString(PreferenceKeys.CALENDAR_MODE.defValue),
         converter = CalendarModeConverter,
         manager = CalendarModeManager
     )
 
     var notification : Boolean by simplePreference.Delegate(
-        key = PreferenceKeys.NOTIFICATION.key,
+        key = PreferenceKeys.NOTIFICATION.getKey(context),
         defValue = PreferenceKeys.NOTIFICATION.defValue,
         converter = BooleanConverter,
         manager = BooleanManager
     )
 
     private var firstLaunch : Boolean by simplePreference.Delegate(
-        key = PreferenceKeys.FIRST_LAUNCH.key,
+        key = PreferenceKeys.FIRST_LAUNCH.getKey(context),
         defValue = PreferenceKeys.FIRST_LAUNCH.defValue,
         converter = BooleanConverter,
         manager = BooleanManager
     )
 
     var codeVersion : Int by simplePreference.Delegate(
-        key = PreferenceKeys.CODE_VERSION.key,
+        key = PreferenceKeys.CODE_VERSION.getKey(context),
         defValue = PreferenceKeys.CODE_VERSION.defValue,
         converter = IntConverter,
         manager = IntManager
     )
 
     var deprecated_notification : String by simplePreference.Delegate(
-        key = PreferenceKeys.DEPRECATED_NOTIFICATION.key,
+        key = PreferenceKeys.DEPRECATED_NOTIFICATION.getKey(context),
         defValue = PreferenceKeys.DEPRECATED_NOTIFICATION.defValue.toString(),
         converter = StringConverter,
         manager = StringManager
     )
 
     var deprecated_firstLaunch : String by simplePreference.Delegate(
-        key = PreferenceKeys.DEPRECATED_FIRST_LAUNCH.key,
+        key = PreferenceKeys.DEPRECATED_FIRST_LAUNCH.getKey(context),
         defValue = PreferenceKeys.DEPRECATED_FIRST_LAUNCH.defValue.toString(),
         converter = StringConverter,
         manager = StringManager

--- a/app/src/main/java/com/edt/ut3/compatibility/CompatibilityManager.kt
+++ b/app/src/main/java/com/edt/ut3/compatibility/CompatibilityManager.kt
@@ -35,13 +35,13 @@ object CompatibilityManager {
         var oldVersion : Int = androidPreferencesManager.run {
             try {
                 return@run getString(
-                        PreferencesManager.PreferenceKeys.CODE_VERSION.key,
+                        PreferencesManager.PreferenceKeys.CODE_VERSION.getKey(context),
                         PreferencesManager.PreferenceKeys.CODE_VERSION.defValue.toString()
                 )?.toInt() ?: PreferencesManager.PreferenceKeys.CODE_VERSION.defValue
             } catch (e: Exception) {
                 try {
                     return@run getInt(
-                            PreferencesManager.PreferenceKeys.CODE_VERSION.key,
+                            PreferencesManager.PreferenceKeys.CODE_VERSION.getKey(context),
                             PreferencesManager.PreferenceKeys.CODE_VERSION.defValue
                     )
                 } catch (e: Exception) {
@@ -97,7 +97,7 @@ object CompatibilityManager {
             androidPreferencesManager.run {
                 edit {
                     putString(
-                            PreferencesManager.PreferenceKeys.LINK.key,
+                            PreferencesManager.PreferenceKeys.LINK.getKey(context),
                             Json.encodeToString(School.default.info.first())
                     )
                 }
@@ -117,7 +117,7 @@ object CompatibilityManager {
                     val notification = PreferencesManager.PreferenceKeys.NOTIFICATION
                     val notificationValue = preferencesManager.deprecated_notification.toBoolean()
                     putBoolean(
-                            notification.key,
+                            notification.getKey(context),
                             notificationValue
                     )
                 } catch (e: Exception) {
@@ -128,7 +128,7 @@ object CompatibilityManager {
                     val firstLaunch = PreferencesManager.PreferenceKeys.FIRST_LAUNCH
                     val firstLaunchValue = preferencesManager.deprecated_firstLaunch.toBoolean()
                     putBoolean(
-                            firstLaunch.key,
+                            firstLaunch.getKey(context),
                             firstLaunchValue
                     )
                 } catch (e: Exception) {
@@ -138,8 +138,8 @@ object CompatibilityManager {
                 try {
                     val codeVersion = PreferencesManager.PreferenceKeys.CODE_VERSION
                     putInt(
-                            PreferencesManager.PreferenceKeys.NOTIFICATION.key,
-                            (getString(codeVersion.key, null)
+                            PreferencesManager.PreferenceKeys.NOTIFICATION.getKey(context),
+                            (getString(codeVersion.getKey(context), null)
                                     ?: codeVersion.defValue.toString()).toInt()
                     )
                 } catch (e: Exception) {

--- a/app/src/main/java/com/edt/ut3/ui/calendar/CalendarFragment.kt
+++ b/app/src/main/java/com/edt/ut3/ui/calendar/CalendarFragment.kt
@@ -56,12 +56,14 @@ class CalendarFragment : BottomSheetFragment(),
 
     private val preferenceChangeListener =
         SharedPreferences.OnSharedPreferenceChangeListener { pref: SharedPreferences, key: String ->
-            when (key) {
-                PreferencesManager.PreferenceKeys.CALENDAR_MODE.key -> {
-                    val newPreference = preferences.calendarMode
-                    updateBarText(calendarViewModel.selectedDate.value!!, newPreference)
+            context?.let { validContext ->
+                when (key) {
+                    PreferencesManager.PreferenceKeys.CALENDAR_MODE.getKey(validContext) -> {
+                        val newPreference = preferences.calendarMode
+                        updateBarText(calendarViewModel.selectedDate.value!!, newPreference)
 
-                    pager?.notifyDataSetChanged()
+                        pager?.notifyDataSetChanged()
+                    }
                 }
             }
         }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -138,4 +138,16 @@
     <string name="downloading_groups">Téléchargement des groupes..</string>
     <string name="channel_firebase_title">Message de la part des créateurs</string>
     <string name="channel_firebase_description">Channel de notification servant à diffuser des informations à l\'ensemble des utilisateurs</string>
+    <string name="key_theme">theme</string>
+    <string name="key_notification">actual_notification</string>
+    <string name="key_section">section</string>
+    <string name="key_about_us">about_us</string>
+    <string name="key_link">link</string>
+    <string name="key_group">groups</string>
+    <string name="old_key_group">old_groups</string>
+    <string name="key_calendar_mode">calendar_mode</string>
+    <string name="key_first_launch">actual_first_launch</string>
+    <string name="key_code_version">actual_code_version</string>
+    <string name="old_key_first_launch">first_launch</string>
+    <string name="old_key_notification">notification</string>
 </resources>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -6,14 +6,14 @@
         app:title="@string/application">
 
         <ListPreference
-            android:key="theme"
+            android:key="@string/key_theme"
             app:title="@string/theme"
             android:entryValues="@array/themesAlias"
             android:entries="@array/themes"
             android:icon="@drawable/ic_theme"/>
 
         <SwitchPreference
-            android:key="actual_notification"
+            android:key="@string/key_notification"
             android:title="@string/enable_update_notifications"
             android:summary="@string/summary_notifications"
             android:icon="@drawable/ic_notifications" />
@@ -24,7 +24,7 @@
         app:title="@string/title_calendar">
 
         <Preference
-            android:key="section"
+            android:key="@string/key_section"
             app:title="@string/calendar_link"
             android:summary="@string/summary_link"
             android:icon="@drawable/ic_group"/>
@@ -36,7 +36,7 @@
 
         <Preference
             android:title="@string/about_us"
-            android:key="about_us"/>
+            android:key="@string/key_about_us"/>
 
     </PreferenceCategory>
 


### PR DESCRIPTION
fix: All usages of PreferenceKeys have been updated to match the new implementation.

Previous implementation was using String to store the Preference keys. This was leading to errors while changing them because almost all the time, changing them into the preferences.xml file was forgot by the programmer. A getter has been added to get the resource with a Context.