### PR TITLE
Delegation of parsing CelcatService data to CelcatDataRetriever

### DIFF
--- a/app/src/main/java/com/edt/ut3/backend/requests/celcat/CelcatDataRetriever.kt
+++ b/app/src/main/java/com/edt/ut3/backend/requests/celcat/CelcatDataRetriever.kt
@@ -1,0 +1,197 @@
+package com.edt.ut3.backend.requests.celcat
+
+import android.content.Context
+import com.edt.ut3.backend.celcat.Event
+import com.edt.ut3.backend.formation_choice.School
+import com.edt.ut3.backend.requests.JsonWebDeserializer
+import com.edt.ut3.backend.requests.authentication_services.Authenticator
+import kotlinx.coroutines.Dispatchers.Default
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import java.io.IOException
+import java.net.SocketTimeoutException
+import java.util.*
+
+@Suppress("BlockingMethodInNonBlockingContext")
+object CelcatDataRetriever {
+
+    /**
+     * Parse the events retrieved by the CelcatService
+     * into a list of [events][Event]
+     *
+     * @param context A valid application context
+     * @param firstUpdate Whether it is the first time
+     * the events will be downloaded
+     * @param link The link where the data should be retrieved
+     * @param groups The groups to which the user is affiliated
+     * @param classes The classes names, used to parse the [Events][Event]
+     * @param courses The courses names, used to parse the [Events][Event]
+     * @return A list of [events][Event].
+     *
+     * @throws SocketTimeoutException When the download timeout
+     * has been reached
+     * @throws IOException When the returned data is invalid
+     * @throws Authenticator.InvalidCredentialsException When the
+     * user's credentials are invalid
+     * @throws SerializationException When the returned data
+     * cannot be parsed with the current configuration
+     */
+    @Throws(
+        Authenticator.InvalidCredentialsException::class,
+        IOException::class,
+        SocketTimeoutException::class,
+        SerializationException::class
+    )
+    suspend fun getEvents(
+        context: Context,
+        firstUpdate: Boolean,
+        link: School.Info,
+        groups: List<String>,
+        classes: HashSet<String>,
+        courses: Map<String, String>
+    ): List<Event> {
+        val response = CelcatService.getEvents(context, firstUpdate, link.url, groups)
+        val body = response.body?.string() ?: throw IOException()
+
+
+        return withContext(Default) {
+            Json.parseToJsonElement(body).jsonArray.fold(listOf()) { acc, e ->
+                try {
+                    acc + Event.fromJSON(e.jsonObject, classes, courses)
+                } catch (e: Exception) {
+                    e.printStackTrace()
+                    acc
+                }
+            }
+        }
+    }
+
+
+    /**
+     * Parses the classes names retrieved by the [CelcatService]
+     * into a list of [String].
+     *
+     * @param context A valid application context
+     * @param link The link from which the classes should be retrieved
+     * @return A list of classes represented by a list of String.
+     *
+     * @throws SocketTimeoutException When the download timeout
+     * has been reached
+     * @throws IOException When the returned data is invalid
+     * @throws Authenticator.InvalidCredentialsException When the
+     * user's credentials are invalid
+     * @throws SerializationException When the returned data
+     * cannot be parsed with the current configuration
+     */
+    @Throws(
+        IOException::class,
+        SocketTimeoutException::class,
+        Authenticator.InvalidCredentialsException::class,
+        SerializationException::class
+    )
+    suspend fun getClasses(context: Context, link: String): List<String> {
+        val response = CelcatService.getClasses(context, link)
+        val body = response.body?.string() ?: throw IOException()
+
+        return withContext(Default) {
+            JsonWebDeserializer.decodeFromString<ClassesRequest>(body).results
+        }
+    }
+
+
+    /**
+     * Parse the [schools information][School] retrieved by [CelcatService].
+     *
+     * @return The school information retrieved by [CelcatService]
+     * as a list of [School].
+     *
+     * @throws SocketTimeoutException When the download timeout
+     * has been reached
+     * @throws IOException When the returned data is invalid
+     * @throws SerializationException When the returned data
+     * cannot be parsed with the current configuration
+     */
+    @Throws(
+        SocketTimeoutException::class,
+        IOException::class,
+        SerializationException::class
+    )
+    suspend fun getSchoolsURLs(): List<School> {
+        val response = CelcatService.getSchoolsURLs()
+        val body = response.body?.string() ?: throw IOException()
+
+        return withContext(Default) {
+            JsonWebDeserializer.decodeFromString<SchoolsRequest>(body).entries
+        }
+    }
+
+
+    /**
+     * Parse the courses names retrieved by the [CelcatService]
+     * into a map of String.
+     * The courses are mapped in the following way :
+     * As an courses are composed by an ID and a Textual representation,
+     * each id is mapped to the textual representation and vice versa.
+     *
+     * @param context A valid application context
+     * @param link The link from which the courses names should
+     * be retrieved
+     * @return A Map of courses names represented as a Map<String, String>
+     *
+     * @throws SocketTimeoutException When the download timeout
+     * has been reached
+     * @throws IOException When the returned data is invalid
+     * @throws SerializationException When the returned data
+     * cannot be parsed with the current configuration
+     */
+    @Throws(
+        IOException::class,
+        SocketTimeoutException::class,
+        SerializationException::class
+    )
+    suspend fun getCoursesNames(context: Context, link: String): Map<String, String> {
+        val response = CelcatService.getCoursesNames(context, link)
+        val body = response.body?.string() ?: throw IOException()
+
+        return withContext(Default) {
+            JsonWebDeserializer.decodeFromString<CoursesRequest>(body).results.toMap()
+        }
+    }
+
+
+    /**
+     * Parse the groups retrieved by the [CelcatService]
+     * into a list of [groups][School.Info.Group].
+     *
+     * @param context A valid application context
+     * @param url The url from where the groups should be retrieve
+     * @return A list of [groups][School.Info.Group]
+     *
+     * @throws SocketTimeoutException When the download timeout
+     * has been reached
+     * @throws IOException When the returned data is invalid
+     * @throws Authenticator.InvalidCredentialsException When the
+     * user's credentials are invalid
+     * @throws SerializationException When the returned data
+     * cannot be parsed with the current configuration
+     */
+    @Throws(
+        SocketTimeoutException::class,
+        IOException::class,
+        Authenticator.InvalidCredentialsException::class,
+        SerializationException::class
+    )
+    suspend fun getGroups(context: Context, url: String): List<School.Info.Group> {
+        val response = CelcatService.getGroups(context, url)
+        val body = response.body?.string() ?: throw IOException()
+
+        return withContext(Default) {
+            JsonWebDeserializer.decodeFromString<GroupsRequest>(body).results
+        }
+    }
+
+}

--- a/app/src/main/java/com/edt/ut3/backend/requests/celcat/CelcatService.kt
+++ b/app/src/main/java/com/edt/ut3/backend/requests/celcat/CelcatService.kt
@@ -3,9 +3,7 @@ package com.edt.ut3.backend.requests.celcat
 import android.content.Context
 import android.util.Log
 import com.edt.ut3.backend.credentials.CredentialsManager
-import com.edt.ut3.backend.formation_choice.School
 import com.edt.ut3.backend.requests.HttpClientProvider
-import com.edt.ut3.backend.requests.JsonWebDeserializer
 import com.edt.ut3.backend.requests.RequestsUtils
 import com.edt.ut3.backend.requests.authentication_services.Authenticator
 import com.edt.ut3.backend.requests.withAuthentication
@@ -16,7 +14,6 @@ import com.edt.ut3.misc.extensions.toCelcatDateStr
 import kotlinx.coroutines.Dispatchers.IO
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.SerializationException
-import kotlinx.serialization.decodeFromString
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
@@ -29,7 +26,31 @@ import java.util.*
 @Suppress("BlockingMethodInNonBlockingContext")
 object CelcatService {
 
-    @Throws(SocketTimeoutException::class, IOException::class, Authenticator.InvalidCredentialsException::class)
+    /**
+     * Retrieves the classes names from
+     * Celcat by doing an authenticated
+     * GET request.
+     *
+     * @param context A valid application context
+     * @param firstUpdate Whether it should be considered as
+     * the first update or not
+     * @param link The download link from which the events
+     * should be downloaded
+     * @param formations The formation that the user follows
+     *
+     * @return The [Response] from the server
+     *
+     * @throws SocketTimeoutException When the download timeout
+     * has been reached
+     * @throws IOException When the returned data is invalid
+     * @throws Authenticator.InvalidCredentialsException When the
+     * user's credentials are invalid
+     */
+    @Throws(
+        SocketTimeoutException::class,
+        IOException::class,
+        Authenticator.InvalidCredentialsException::class
+    )
     suspend fun getEvents(
         context: Context,
         firstUpdate: Boolean,
@@ -72,8 +93,30 @@ object CelcatService {
     }
 
 
-    @Throws(SocketTimeoutException::class, IOException::class, SerializationException::class, Authenticator.InvalidCredentialsException::class)
-    suspend fun getClasses(context: Context, link: String) = withContext(IO) {
+    /**
+     * Retrieves the classes names from
+     * Celcat by doing an authenticated
+     * GET request.
+     *
+     *
+     * @param context A valid application Context
+     * @param link The link from where the classes names
+     * should be retrieved.
+     *
+     * @return The [Response] from the server
+     *
+     * @throws SocketTimeoutException When the download timeout
+     * has been reached
+     * @throws IOException When the returned data is invalid
+     * @throws Authenticator.InvalidCredentialsException When the
+     * user's credentials are invalid
+     */
+    @Throws(
+        SocketTimeoutException::class,
+        IOException::class,
+        Authenticator.InvalidCredentialsException::class
+    )
+    suspend fun getClasses(context: Context, link: String): Response = withContext(IO) {
         Log.d(this@CelcatService::class.simpleName, "Downloading classes: $link")
         val request = Request.Builder()
             .url(link)
@@ -89,13 +132,33 @@ object CelcatService {
                 newCall(request).execute()
             }
 
-        val body = response.body?.string() ?: throw IOException()
-
-        JsonWebDeserializer.decodeFromString<ClassesRequest>(body).results
+        response
     }
 
-    @Throws(SocketTimeoutException::class, IOException::class, SerializationException::class, Authenticator.InvalidCredentialsException::class)
-    suspend fun getCoursesNames(context: Context, link: String) = withContext(IO) {
+
+    /**
+     * Retrieves the courses names from
+     * Celcat by doing an authenticated
+     * GET request.
+     *
+     * @param context A valid application Context
+     * @param link The link from where the courses names
+     * should be retrieved.
+     *
+     * @return The [Response] from the server
+     *
+     * @throws SocketTimeoutException When the download timeout
+     * has been reached
+     * @throws IOException When the returned data is invalid
+     * @throws Authenticator.InvalidCredentialsException When the
+     * user's credentials are invalid
+     */
+    @Throws(
+        SocketTimeoutException::class,
+        IOException::class,
+        Authenticator.InvalidCredentialsException::class
+    )
+    suspend fun getCoursesNames(context: Context, link: String): Response = withContext(IO) {
         Log.d(this@CelcatService::class.simpleName, "Downloading courses: $link")
         val request = Request.Builder()
             .url(link)
@@ -111,13 +174,24 @@ object CelcatService {
                 newCall(request).execute()
             }
 
-        val body = response.body?.string() ?: throw IOException()
-
-        JsonWebDeserializer.decodeFromString<CoursesRequest>(body).results.toMap()
+        response
     }
 
+
+    /**
+     * Retrieves the school information from
+     * Github by doing a GET request.
+     *
+     * @return The [Response] from the server
+     *
+     * @throws SocketTimeoutException When the download timeout
+     * has been reached
+     * @throws IOException When the returned data is invalid
+     * @throws Authenticator.InvalidCredentialsException When the
+     * user's credentials are invalid
+     */
     @Throws(SocketTimeoutException::class, IOException::class, SerializationException::class)
-    suspend fun getSchoolsURLs(): List<School> = withContext(IO) {
+    suspend fun getSchoolsURLs(): Response = withContext(IO) {
         val request = Request.Builder()
             .url("https://raw.githubusercontent.com/axellaffite/ut3_calendar/master/data/formations/urls.json")
             .get()
@@ -128,16 +202,36 @@ object CelcatService {
             .newCall(request)
             .execute()
 
-        val body = response.body?.string() ?: throw IOException()
-
-        JsonWebDeserializer.decodeFromString<SchoolsRequest>(body).entries
+        response
     }
 
-    @Throws(SocketTimeoutException::class, IOException::class, Authenticator.InvalidCredentialsException::class, SerializationException::class)
-    suspend fun getGroups(context: Context, url: String): List<School.Info.Group> = withContext(IO) {
-        Log.i(this@CelcatService::class.simpleName, "Getting groups: $url")
+
+    /**
+     * Retrieve the group names from
+     * Celcat by doing an authenticated
+     * GET request.
+     *
+     * @param context A valid application Context
+     * @param link The link from where the group names
+     * should be retrieved.
+     *
+     * @return The [Response] from the server
+     *
+     * @throws SocketTimeoutException When the download timeout
+     * has been reached
+     * @throws IOException When the returned data is invalid
+     * @throws Authenticator.InvalidCredentialsException When the
+     * user's credentials are invalid
+     */
+    @Throws(
+        SocketTimeoutException::class,
+        IOException::class,
+        Authenticator.InvalidCredentialsException::class,
+    )
+    suspend fun getGroups(context: Context, link: String): Response = withContext(IO) {
+        Log.i(this@CelcatService::class.simpleName, "Getting groups: $link")
         val request = Request.Builder()
-            .url(url)
+            .url(link)
             .get()
             .build()
 
@@ -150,9 +244,7 @@ object CelcatService {
                 newCall(request).execute()
             }
 
-        val body = response.body?.string() ?: throw IOException()
-
-        JsonWebDeserializer.decodeFromString<GroupsRequest>(body).results
+        response
     }
 
 }

--- a/app/src/main/java/com/edt/ut3/ui/preferences/formation/FormationSelectionViewModel.kt
+++ b/app/src/main/java/com/edt/ut3/ui/preferences/formation/FormationSelectionViewModel.kt
@@ -12,7 +12,7 @@ import com.edt.ut3.backend.formation_choice.School
 import com.edt.ut3.backend.preferences.PreferencesManager
 import com.edt.ut3.backend.requests.authentication_services.Authenticator
 import com.edt.ut3.backend.requests.authentication_services.CelcatAuthenticator
-import com.edt.ut3.backend.requests.celcat.CelcatService
+import com.edt.ut3.backend.requests.celcat.CelcatDataRetriever
 import com.edt.ut3.misc.BaseState
 import com.edt.ut3.misc.extensions.isTrue
 import com.edt.ut3.misc.extensions.toList
@@ -112,7 +112,7 @@ class FormationSelectionViewModel: ViewModel() {
         groupsDownloadJob = viewModelScope.launch {
             _groupsStatus.value = WhichGroupsState.Downloading
             val success: Boolean = try {
-                val newGroups = CelcatService.getGroups(context, School.default.info.first().groups)
+                val newGroups = CelcatDataRetriever.getGroups(context, School.default.info.first().groups)
                 synchronized(groups) {
                     _groups.clear()
                     _groups.addAll(newGroups)


### PR DESCRIPTION
refactor: The data retrieved by the CelcatService is now parsed by the CelcatDataRetriever.
fix: Usages of CelcatService.kt removed to match the new implementation.
doc: Documentation added to CelcatService.kt and CelcatDataRetriever.kt.