### PR TITLE
Modifié le formattage de la date de semaine

### DIFF
--- a/app/src/main/java/com/edt/ut3/ui/calendar/CalendarFragment.kt
+++ b/app/src/main/java/com/edt/ut3/ui/calendar/CalendarFragment.kt
@@ -437,10 +437,10 @@ class CalendarFragment : BottomSheetFragment(),
                 }
 
                 else -> {
-                    val start = SimpleDateFormat("EEE dd/MM/yyyy", Locale.getDefault()).format(
+                    val start = SimpleDateFormat("EEE dd/MM", Locale.getDefault()).format(
                         beginDate
                     )
-                    val end = SimpleDateFormat("EEE dd/MM/yyyy", Locale.getDefault()).format(
+                    val end = SimpleDateFormat("EEE dd/MM", Locale.getDefault()).format(
                         beginDate.add(
                             Calendar.DAY_OF_YEAR,
                             dayCount - 1


### PR DESCRIPTION
L'année actuelle a été enlevée du formatage de la date en vue semaine entière du calendrier, pour afficher la date complète en mode portrait.
![Screenshot_2022-09-16-19-33-28-85_ed1f7120e2eeaa3b37be83033eacdf41](https://user-images.githubusercontent.com/27915772/190699071-13fffe20-e7b3-4272-a5a7-c5b5c0dd6632.jpg)

_Salutations ! Etudiant à Polsab et utilisateur enthousiaste de votre appli depuis quelques jours, je tenais à vous remercier de votre super travail, en même temps qu'aider un peu à l'effort dans la mesure de mes moyens !
Je ne suis pas très compétent en développement android, mais je trouverai peut-être quelques trucs à faire ^^ (très petit PR, mais c'était surtout pour me familiariser avec la codebase et mettre en place l'environnement...)_