### PR TITLE
Fix la récupération des groupes

### DIFF
--- a/app/src/main/java/com/edt/ut3/ui/preferences/formation/FormationSelectionViewModel.kt
+++ b/app/src/main/java/com/edt/ut3/ui/preferences/formation/FormationSelectionViewModel.kt
@@ -31,6 +31,8 @@ import java.io.IOException
 class FormationSelectionViewModel: ViewModel() {
     private var groupsDownloadJob: Job? = null
 
+    private var client = getClient()
+
     private val _authenticationFailure = MutableLiveData<AuthenticationFailure?>(null)
     val authenticationFailure : LiveData<AuthenticationFailure?>
         get() = _authenticationFailure
@@ -88,7 +90,7 @@ class FormationSelectionViewModel: ViewModel() {
         } else {
             _authenticationState.value = AuthenticationState.Authenticating
             try {
-                AuthenticatorUT3(getClient()).checkCredentials(credentials)
+                AuthenticatorUT3(client).checkCredentials(credentials)
                 _authenticationState.value = AuthenticationState.Authenticated
                 true
             } catch (e: Exception) {
@@ -111,7 +113,7 @@ class FormationSelectionViewModel: ViewModel() {
             _groupsStatus.value = WhichGroupsState.Downloading
             val success: Boolean = try {
                 val link = School.default.info.first().get(resourceType.value)
-                val newGroups = CelcatService(getClient()).getGroups(link)
+                val newGroups = CelcatService(client).getGroups(link)
                 synchronized(groups) {
                     _groups.clear()
                     _groups.addAll(newGroups)


### PR DESCRIPTION
Heya ! 
J'ai remarqué que la récupération des groupes échouait lors de la connexion. Le bug était relativement simple à fixer, il fallait faire persister les cookies, et donc le client entre les requêtes.
Je ne programme pas couramment en Kotlin, donc si ça se trouve c'est pas comme ça qu'on fait, mais ça marche...

Merci pour votre travail sur cette app !

Elie Donadio